### PR TITLE
Add repos command to display popular GitHub repositories

### DIFF
--- a/Commands/ReposCommand.cs
+++ b/Commands/ReposCommand.cs
@@ -1,0 +1,105 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Ardalis.Commands;
+
+public class ReposCommand : AsyncCommand
+{
+    private static readonly HttpClient _httpClient = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
+    private static readonly string[] RepoNames = new[]
+    {
+        "CleanArchitecture",
+        "ApiEndpoints",
+        "Specification",
+        "GuardClauses",
+        "Result",
+        "SmartEnum"
+    };
+
+    static ReposCommand()
+    {
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "ardalis-cli");
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context)
+    {
+        AnsiConsole.MarkupLine("[bold green]Ardalis's Popular GitHub Repositories[/]\n");
+
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.AddColumn("[bold]Repository[/]");
+        table.AddColumn("[bold]Stars[/]");
+        table.AddColumn("[bold]Description[/]");
+
+        foreach (var repoName in RepoNames)
+        {
+            try
+            {
+                var repoInfo = await GetRepoInfo(repoName);
+                if (repoInfo != null)
+                {
+                    var stars = repoInfo.StargazersCount.ToString("N0");
+                    var description = repoInfo.Description ?? "No description";
+                    
+                    // Truncate description if too long
+                    if (description.Length > 60)
+                    {
+                        description = description.Substring(0, 57) + "...";
+                    }
+
+                    table.AddRow(
+                        $"[link={repoInfo.HtmlUrl}]{repoName}[/]",
+                        $"[yellow]⭐ {stars}[/]",
+                        $"[dim]{description}[/]"
+                    );
+                }
+            }
+            catch
+            {
+                // Skip repos that fail to load
+                table.AddRow(
+                    $"{repoName}",
+                    "[dim]N/A[/]",
+                    "[dim]Failed to load[/]"
+                );
+            }
+        }
+
+        AnsiConsole.Write(table);
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[dim]Visit: [link]https://github.com/ardalis[/][/]");
+
+        return 0;
+    }
+
+    private static async Task<GitHubRepo> GetRepoInfo(string repoName)
+    {
+        var url = $"https://api.github.com/repos/ardalis/{repoName}";
+        var response = await _httpClient.GetStringAsync(url);
+        return JsonSerializer.Deserialize<GitHubRepo>(response, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        })!;
+    }
+
+    private class GitHubRepo
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        
+        [JsonPropertyName("stargazers_count")]
+        public int StargazersCount { get; set; }
+        
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; set; } = string.Empty;
+    }
+}

--- a/InteractiveMode.cs
+++ b/InteractiveMode.cs
@@ -10,7 +10,7 @@ public static class InteractiveMode
     public static async Task<int> RunAsync()
     {
         AnsiConsole.MarkupLine("[bold deepskyblue3]Interactive Mode[/]");
-        AnsiConsole.MarkupLine("[dim]Enter commands (card, blog, youtube, quote). Press Ctrl+C or type 'exit' to quit.[/]\n");
+        AnsiConsole.MarkupLine("[dim]Enter commands (card, blog, youtube, quote, repos). Press Ctrl+C or type 'exit' to quit.[/]\n");
 
         while (true)
         {
@@ -51,6 +51,10 @@ public static class InteractiveMode
                         await new QuoteCommand().ExecuteAsync(null!);
                         break;
                     
+                    case "repos":
+                        await new ReposCommand().ExecuteAsync(null!);
+                        break;
+                    
                     case "help":
                     case "?":
                         AnsiConsole.MarkupLine("[bold]Available commands:[/]");
@@ -58,6 +62,7 @@ public static class InteractiveMode
                         AnsiConsole.MarkupLine("  [deepskyblue3]blog[/]    - Open blog");
                         AnsiConsole.MarkupLine("  [deepskyblue3]youtube[/] - Open YouTube channel");
                         AnsiConsole.MarkupLine("  [deepskyblue3]quote[/]   - Display random quote");
+                        AnsiConsole.MarkupLine("  [deepskyblue3]repos[/]   - Display popular GitHub repositories");
                         AnsiConsole.MarkupLine("  [deepskyblue3]exit[/]    - Exit interactive mode");
                         break;
                     

--- a/Program.cs
+++ b/Program.cs
@@ -26,6 +26,9 @@ app.Configure(config =>
 
     config.AddCommand<QuoteCommand>("quote")
         .WithDescription("Display a random Ardalis quote.");
+
+    config.AddCommand<ReposCommand>("repos")
+        .WithDescription("Display popular Ardalis GitHub repositories.");
         
     config.AddExample("card");
     config.AddExample("blog");


### PR DESCRIPTION
## Description
This PR implements issue #9 by adding a new epos command that displays popular Ardalis GitHub repositories.

## Changes
- Created ReposCommand.cs that fetches repository information from the public GitHub API
- Displays repository name, star count, and description in a nicely formatted table using Spectre.Console
- No authentication required - uses public GitHub API endpoints
- Added the epos command to both the main CLI and interactive mode
- Updated interactive mode help text to include the new command

## Featured Repositories
- CleanArchitecture
- ApiEndpoints
- Specification
- GuardClauses
- Result
- SmartEnum

## Testing
Tested both standalone mode (dotnet run -- repos) and in interactive mode. The command successfully fetches and displays repository data with proper formatting.

Closes #9