### PR TITLE
Add books command to display published books

### DIFF
--- a/Commands/BooksCommand.cs
+++ b/Commands/BooksCommand.cs
@@ -1,0 +1,157 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Ardalis.Commands;
+
+public class BooksCommand : AsyncCommand
+{
+    private static readonly HttpClient _httpClient = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
+    private const string BooksJsonUrl = "https://ardalis.com/books.json";
+
+    static BooksCommand()
+    {
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "ardalis-cli");
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context)
+    {
+        AnsiConsole.MarkupLine("[bold blue]Ardalis's Published Books[/]\n");
+
+        List<Book> books;
+        
+        try
+        {
+            // Try to fetch books from the URL
+            books = await FetchBooksFromUrl();
+        }
+        catch
+        {
+            // Fallback to hard-coded book if URL is unavailable
+            AnsiConsole.MarkupLine("[dim]Using fallback book list...[/]\n");
+            books = GetFallbackBooks();
+        }
+
+        if (books.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]No books available at the moment.[/]");
+            return 0;
+        }
+
+        // Sort books by publication date (most recent first)
+        var sortedBooks = books
+            .OrderByDescending(b => ParsePublicationYear(b.PublicationDate))
+            .ToList();
+
+        // Display books
+        foreach (var book in sortedBooks)
+        {
+            DisplayBook(book);
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[dim]Learn more at: [link]https://ardalis.com/books[/][/]");
+
+        return 0;
+    }
+
+    private static async Task<List<Book>> FetchBooksFromUrl()
+    {
+        var response = await _httpClient.GetStringAsync(BooksJsonUrl);
+        var books = JsonSerializer.Deserialize<List<Book>>(response, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        return books ?? new List<Book>();
+    }
+
+    private static List<Book> GetFallbackBooks()
+    {
+        return new List<Book>
+        {
+            new Book
+            {
+                Title = "Architecting Modern Web Applications with ASP.NET Core and Microsoft Azure",
+                Link = "https://ardalis.com/architecture-ebook/",
+                CoverImage = "https://ardalis.com/img/Architecture-eBook-Cover-242x300.png",
+                Description = "Learn how to architect modern web applications using ASP.NET Core and Azure. This free eBook covers architecture patterns, clean code practices, and cloud deployment strategies.",
+                Publisher = "Microsoft",
+                PublicationDate = "2023"
+            }
+        };
+    }
+
+    private static void DisplayBook(Book book)
+    {
+        var panel = new Panel(new Markup(
+            $"[bold]{book.Title}[/]\n\n" +
+            $"{(string.IsNullOrEmpty(book.Description) ? "[dim]No description available[/]" : book.Description)}\n\n" +
+            $"[dim]Publisher:[/] {(string.IsNullOrEmpty(book.Publisher) ? "N/A" : book.Publisher)}\n" +
+            $"[dim]Published:[/] {(string.IsNullOrEmpty(book.PublicationDate) ? "N/A" : book.PublicationDate)}\n\n" +
+            $"[link={book.Link}]Read More →[/]"
+        ))
+        {
+            Border = BoxBorder.Rounded,
+            BorderStyle = new Style(Color.Blue),
+            Padding = new Padding(1, 0, 1, 0)
+        };
+
+        AnsiConsole.Write(panel);
+        AnsiConsole.WriteLine();
+    }
+
+    private static int ParsePublicationYear(string publicationDate)
+    {
+        if (string.IsNullOrWhiteSpace(publicationDate))
+            return 0;
+
+        // Try to parse as a year directly
+        if (int.TryParse(publicationDate, out int year))
+            return year;
+
+        // Try to extract year from various date formats
+        if (DateTime.TryParse(publicationDate, out DateTime date))
+            return date.Year;
+
+        // If all else fails, try to find a 4-digit year in the string
+        var match = System.Text.RegularExpressions.Regex.Match(publicationDate, @"\b(19|20)\d{2}\b");
+        if (match.Success && int.TryParse(match.Value, out int extractedYear))
+            return extractedYear;
+
+        return 0;
+    }
+
+    private class Book
+    {
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("link")]
+        public string Link { get; set; } = string.Empty;
+
+        [JsonPropertyName("coverImage")]
+        public string CoverImage { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("publisher")]
+        public string Publisher { get; set; } = string.Empty;
+
+        [JsonPropertyName("publicationDate")]
+        public string PublicationDate { get; set; } = string.Empty;
+
+        [JsonPropertyName("isbn")]
+        public string Isbn { get; set; } = string.Empty;
+    }
+}

--- a/InteractiveMode.cs
+++ b/InteractiveMode.cs
@@ -10,7 +10,7 @@ public static class InteractiveMode
     public static async Task<int> RunAsync()
     {
         AnsiConsole.MarkupLine("[bold deepskyblue3]Interactive Mode[/]");
-        AnsiConsole.MarkupLine("[dim]Enter commands (card, blog, youtube, quote, repos). Press Ctrl+C or type 'exit' to quit.[/]\n");
+        AnsiConsole.MarkupLine("[dim]Enter commands (card, blog, youtube, quote, repos, books). Press Ctrl+C or type 'exit' to quit.[/]\n");
 
         while (true)
         {
@@ -55,6 +55,10 @@ public static class InteractiveMode
                         await new ReposCommand().ExecuteAsync(null!);
                         break;
                     
+                    case "books":
+                        await new BooksCommand().ExecuteAsync(null!);
+                        break;
+                    
                     case "help":
                     case "?":
                         AnsiConsole.MarkupLine("[bold]Available commands:[/]");
@@ -63,6 +67,7 @@ public static class InteractiveMode
                         AnsiConsole.MarkupLine("  [deepskyblue3]youtube[/] - Open YouTube channel");
                         AnsiConsole.MarkupLine("  [deepskyblue3]quote[/]   - Display random quote");
                         AnsiConsole.MarkupLine("  [deepskyblue3]repos[/]   - Display popular GitHub repositories");
+                        AnsiConsole.MarkupLine("  [deepskyblue3]books[/]   - Display published books");
                         AnsiConsole.MarkupLine("  [deepskyblue3]exit[/]    - Exit interactive mode");
                         break;
                     

--- a/Program.cs
+++ b/Program.cs
@@ -29,6 +29,9 @@ app.Configure(config =>
 
     config.AddCommand<ReposCommand>("repos")
         .WithDescription("Display popular Ardalis GitHub repositories.");
+
+    config.AddCommand<BooksCommand>("books")
+        .WithDescription("Display published books by Ardalis.");
         
     config.AddExample("card");
     config.AddExample("blog");

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Display popular GitHub repositories:
 dnx ardalis repos
 ```
 
+Display published books:
+
+```bash
+dnx ardalis books
+```
+
 Check the version:
 
 ```bash
@@ -80,6 +86,9 @@ In interactive mode, simply type commands:
 > repos
 (displays popular GitHub repositories with stars)
 
+> books
+(displays published books)
+
 > blog
 (opens blog)
 
@@ -105,6 +114,7 @@ ardalis blog       # Open blog
 ardalis youtube    # Open YouTube channel
 ardalis quote      # Display random quote
 ardalis repos      # Display popular GitHub repositories
+ardalis books      # Display published books
 ardalis --version  # Check version
 ```
 


### PR DESCRIPTION
Fixes #10

This PR implements a new ooks command that displays published books by Ardalis.

## Changes
- Added new BooksCommand that fetches books from https://ardalis.com/books.json
- Fallback to hard-coded book if URL is unavailable (includes Microsoft eBook from 2023)
- Books are sorted by publication date (most recent first)
- Beautiful UI using Spectre.Console with rounded panels
- Command registered in both CLI and interactive mode
- Updated README.md with documentation

## Features
- Fetches book data from remote JSON endpoint
- Graceful fallback with hard-coded sample book
- Flexible date parsing (handles year strings, full dates, and embedded years)
- Clean visual presentation with links to read more
- Displays publisher and publication date information