### PR TITLE
Update TimeWarp.Nuru to 3.0.0-beta.19 and bump version to 1.20.0

### DIFF
--- a/ardalis.csproj
+++ b/ardalis.csproj
@@ -16,7 +16,7 @@
     <RollForward>Major</RollForward>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.19.0</Version>
+    <Version>1.20.0</Version>
     <ReleaseNotes>Updated to use TimeWarp.Nuru and routes and command pipelines Thanks @StevenTCramer!.</ReleaseNotes>
     <RootNamespace>Ardalis.Cli</RootNamespace>
   </PropertyGroup>
@@ -36,7 +36,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageReference Include="PostHog.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="TimeWarp.Nuru" Version="3.0.0-beta.15" />
+    <PackageReference Include="TimeWarp.Nuru" Version="3.0.0-beta.19" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Update TimeWarp.Nuru from 3.0.0-beta.15 to 3.0.0-beta.19 for latest improvements
- Bump package version from 1.19.0 to 1.20.0