### PR TITLE
Add dotnetconf-stats alias for dotnetconf-score command

### DIFF
--- a/src/Ardalis.Cli/Ardalis.Cli.csproj
+++ b/src/Ardalis.Cli/Ardalis.Cli.csproj
@@ -16,8 +16,8 @@
     <RollForward>Major</RollForward>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.23.0</Version>
-    <ReleaseNotes>Added --output/-o option to dotnetconf-score command to export results as a markdown file.</ReleaseNotes>
+    <Version>1.24.0</Version>
+    <ReleaseNotes>Added dotnetconf-stats as an alias for the dotnetconf-score command.</ReleaseNotes>
     <RootNamespace>Ardalis.Cli</RootNamespace>
     <InterceptorsNamespaces>$(InterceptorsNamespaces);TimeWarp.Nuru.Generated</InterceptorsNamespaces>
   </PropertyGroup>

--- a/src/Ardalis.Cli/Endpoints/DotNetConfScoreEndpoint.cs
+++ b/src/Ardalis.Cli/Endpoints/DotNetConfScoreEndpoint.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,6 +20,7 @@ namespace Ardalis.Cli.Endpoints;
 /// Displays top videos from .NET Conf playlists using Nuru table widget.
 /// </summary>
 [NuruRoute("dotnetconf-score", Description = "Display top videos from .NET Conf playlists. Use --output <file.md> to save results as a markdown file.")]
+[NuruRouteAlias("dotnetconf-stats")]
 public sealed class DotNetConfScoreEndpoint : IQuery<Unit>
 {
     [Parameter(Description = "Year to display scores for")]


### PR DESCRIPTION
## Summary

- Added `dotnetconf-stats` as an alias for the `dotnetconf-score` command using `[NuruRouteAlias]`
- Bumped version from 1.23.0 to 1.24.0

## Test plan

- [ ] Run `ardalis dotnetconf-stats` and verify it produces the same output as `ardalis dotnetconf-score`
- [ ] Run `ardalis dotnetconf-stats 2024` to verify the year parameter still works
- [ ] Run `ardalis dotnetconf-score` to verify the primary command still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)