### PR TITLE
Fix CI pack: missing README path, OTel vulnerability warnings, nullable warning

### DIFF
--- a/src/Ardalis.Cli/Ardalis.Cli.csproj
+++ b/src/Ardalis.Cli/Ardalis.Cli.csproj
@@ -23,14 +23,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="PostHog.AspNetCore" Version="2.4.1" />
     <PackageReference Include="TimeWarp.Nuru" Version="3.0.0-beta.68" />
   </ItemGroup>

--- a/src/Ardalis.Cli/Helpers/UrlHelper.cs
+++ b/src/Ardalis.Cli/Helpers/UrlHelper.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
## Summary

- Fixed `NU5019` error: `PackageReadmeFile` `<None Include>` was pointing to `README.md` relative to the project directory, which doesn't exist — updated to `..\..\README.md` to reference the root-level README
- Fixed `NU1902` warnings: bumped `OpenTelemetry.Exporter.OpenTelemetryProtocol` and `OpenTelemetry.Extensions.Hosting` from `1.15.1` → `1.15.3` to resolve known moderate-severity vulnerabilities (GHSA-g94r-2vxg-569j, GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933)
- Fixed pre-existing `CS8632` warning in `UrlHelper.cs`: added `#nullable enable` so the `Process?` return type annotation is in a valid nullable context

## Test plan

- [ ] `dotnet restore` completes without errors
- [ ] `dotnet build --configuration Release` produces 0 warnings, 0 errors
- [ ] `dotnet pack --configuration Release --no-build --no-restore` succeeds and produces a `.nupkg`
- [ ] CI publish workflow passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)